### PR TITLE
Add ephemeral cache and extended thinking

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ javaTarget = "17"
 kotlin = "2.2.21"
 kotlinxSerialization = "1.9.0"
 
-anthropicSdkKotlin = "0.24.0"
+anthropicSdkKotlin = "0.26.0"
 xemanticKotlinTest = "1.15.2"
 
 ktor = "3.3.2"

--- a/src/commonMain/kotlin/Claudine.kt
+++ b/src/commonMain/kotlin/Claudine.kt
@@ -96,14 +96,17 @@ suspend fun claudine(): Int {
 
     var totalStats = CostWithUsage.ZERO
     val conversation = mutableListOf<Message>()
+
     val systemPrompt = listOf(
         System(
             text = """
                 $claudineSystemPrompt
-                
+
                 ${describeCurrentMoment()}
             """.trimIndent(),
-            cacheControl = CacheControl.Ephemeral()
+            cacheControl = CacheControl.Ephemeral {
+                ttl = CacheControl.Ephemeral.TTL.ONE_HOUR
+            }
         )
     )
 
@@ -133,7 +136,11 @@ suspend fun claudine(): Int {
             }
             val response = anthropic.messages.create {
                 system = systemPrompt
-                messages = conversation.addCacheBreakpoint()
+                messages = conversation.addCacheBreakpoint(
+                    cacheControl = CacheControl.Ephemeral {
+                        ttl = CacheControl.Ephemeral.TTL.ONE_HOUR
+                    }
+                )
                 tools = toolbox.tools
             }
             if (response.stopReason == StopReason.MAX_TOKENS) {

--- a/src/commonMain/kotlin/Claudine.kt
+++ b/src/commonMain/kotlin/Claudine.kt
@@ -21,6 +21,7 @@ package com.xemantic.ai.claudine
 import com.xemantic.ai.anthropic.Anthropic
 import com.xemantic.ai.anthropic.AnthropicConfigException
 import com.xemantic.ai.anthropic.cache.CacheControl
+import com.xemantic.ai.anthropic.content.ThinkingBlock
 import com.xemantic.ai.anthropic.cost.CostWithUsage
 import com.xemantic.ai.anthropic.cost.costReport
 import com.xemantic.ai.anthropic.message.Message
@@ -28,6 +29,7 @@ import com.xemantic.ai.anthropic.message.StopReason
 import com.xemantic.ai.anthropic.message.System
 import com.xemantic.ai.anthropic.message.addCacheBreakpoint
 import com.xemantic.ai.anthropic.message.plusAssign
+import com.xemantic.ai.anthropic.thinking.ThinkingConfigEnabled
 import com.xemantic.ai.anthropic.tool.Toolbox
 import com.xemantic.ai.claudine.tool.CreateFile
 import com.xemantic.ai.claudine.tool.ExecuteShellCommand
@@ -142,6 +144,9 @@ suspend fun claudine(): Int {
                     }
                 )
                 tools = toolbox.tools
+                thinking = ThinkingConfigEnabled {
+                    budgetTokens = 2048
+                }
             }
             if (response.stopReason == StopReason.MAX_TOKENS) {
                 println("[Claudine]> Error: max number of output tokens reached")
@@ -152,6 +157,13 @@ suspend fun claudine(): Int {
             }
 
             conversation += response
+
+            // Display thinking process if available
+            response.content.filterIsInstance<ThinkingBlock>().firstOrNull()?.let { thinkingBlock ->
+                print("[Claudine - Thinking]> ")
+                println(thinkingBlock.thinking)
+                println()
+            }
 
             response.text?.run {
                 println("[Claudine]> ${response.text}")


### PR DESCRIPTION
This pull requests implements support for ephemeral cache support with conditional conversation caching and extended thinking in Claudine.

Conditional conversation caching activates only when the conversation exceeds the minimum cacheable token threshold (1024 tokens), avoiding wasted cache costs on small conversations.

This pull requests depends on:
- [#95 -  Add extended thinking support](https://github.com/xemantic/anthropic-sdk-kotlin/pull/95) in [anthropic-sdk-kotlin](https://github.com/xemantic/anthropic-sdk-kotlin)
- [#10 -  Update anthropic-sdk-kotlin to 0.26.0](https://github.com/xemantic/claudine/pull/10) in [claudine](https://github.com/xemantic/claudine/pull/10).

Please merge those pull requests first.

Example:
```
nastya@thinkpad:~/projects/xemantic/claudine(feature/ephemeralCacheAndExtendedThinking)$ ./claudine
[Claudine]> Connecting human and human's machine to cognition of Claude AI
[me]> What do you think about Constantine P. Cavafy poetry?
[Claudine] ...Reasoning...
[Claudine - Thinking]> The user is asking me about Constantine P. Cavafy's poetry - specifically what I think about it. This is a general question about literature and poetry, not a request to perform any actions with the tools I have available.

Constantine P. Cavafy (1863-1933) was a renowned Greek poet from Alexandria, Egypt. He's considered one of the most distinguished Greek poets of the 20th century. His work is known for its historical themes, sensuality, and philosophical depth.

This is a conversational question that doesn't require me to use any of the provided tools (ExecuteShellCommand, CreateFile, ReadBinaryFiles, ReadFiles, OpenUrl). I should just respond with my thoughts on Cavafy's poetry as Claude would.

[Claudine]> I find Cavafy's poetry remarkable for several reasons:

**Historical Imagination**: He had an extraordinary ability to inhabit ancient moments - particularly from Hellenistic and Roman periods - and make them feel intimate and psychologically complex. Poems like "Waiting for the Barbarians" and "Ithaka" use historical or mythological settings to explore timeless human experiences.

**Understated Elegance**: His style is deceptively simple, almost conversational, yet profoundly layered. He avoids grand rhetoric in favor of precise, measured language that reveals depths gradually.

**Sensuality and Honesty**: For his time, Cavafy was remarkably open about homoerotic desire. His love poems have a poignant quality - mixing memory, longing, and an acute awareness of time's passage. There's often a bittersweet quality to them.

**Philosophical Depth**: "Ithaka" is perhaps his most famous work, with its message that the journey matters more than the destination - a metaphor for life itself. His work frequently meditates on fate, choice, dignity in defeat, and the gap between aspiration and reality.

**The Weight of Time**: Many poems explore how we construct meaning from fleeting moments, and how memory transforms experience. There's often a retrospective quality, looking back with wisdom tinged by melancholy.

Do you have a favorite Cavafy poem, or are you just discovering his work? His influence on modern poetry has been profound, inspiring everyone from Auden to Brodsky.
[Claudine]> Tax:
|                | request tokens | total tokens | request cost | total cost |
|----------------|----------------|--------------|--------------|------------|
| input          |            367 |          367 |    $0.001101 |  $0.001101 |
| output         |            514 |          514 |     $0.00771 |   $0.00771 |
| cache 5m write |              0 |            0 |           $0 |         $0 |
| cache 1h write |           1454 |         1454 |    $0.008724 |  $0.008724 |
| cache read     |              0 |            0 |           $0 |         $0 |
|                |                |              |              |            |
|                |                |              |    $0.017535 |  $0.017535 |
|
[me]> Read the poem from text file located at /tmp/poetry/The_Afternoon_Sun.txt and tell me what do you think about it?
[Claudine] ...Reasoning...
[Claudine - Thinking]> The user wants me to read a poem from a text file and share my thoughts about it. I should use the ReadFiles tool to read the file at /tmp/poetry/The_Afternoon_Sun.txt.

First, I should check if it's a good practice to check the file size, but for a text file containing a poem, it's very unlikely to be large, so I can proceed with reading it directly.

[Claudine]> Tax:
|                | request tokens | total tokens | request cost | total cost |
|----------------|----------------|--------------|--------------|------------|
| input          |            744 |         1111 |    $0.002232 |  $0.003333 |
| output         |            197 |          711 |    $0.002955 |  $0.010665 |
| cache 5m write |              0 |            0 |           $0 |         $0 |
| cache 1h write |              0 |         1454 |           $0 |  $0.008724 |
| cache read     |           1454 |         1454 |   $0.0004362 | $0.0004362 |
|                |                |              |              |            |
|                |                |              |   $0.0056232 | $0.0231582 |
|
[Claudine]> Using ReadFiles to: Read Cavafy's poem "The Afternoon Sun" to analyze and discuss it
|
| - /tmp/poetry/The_Afternoon_Sun.txt
|
[Claudine] ...Processing tool results...
[Claudine]> What a devastatingly beautiful poem. This is Cavafy at his most emotionally direct and vulnerable.

**The Power of Understatement**: The entire tragedy is contained in those last few lines, delivered with almost casual matter-of-factness: "that week became forever." No melodrama, no elaborate metaphor—just the brutal simplicity of loss. The ellipses before it create this pause, a breath before the revelation.

**Memory and Space**: The way he meticulously reconstructs the room—the couch, the Turkish carpet, the yellow vases, the wardrobe—feels like an act of preservation. He's trying to hold onto what's been erased, literally overlaying memory onto the sterile office space it's become. The slight confusion ("On the right—no, opposite") makes the memory feel authentic, lived-in.

**The Afternoon Sun**: What a perfect recurring image. It's both specific (touching half the bed) and symbolic—warmth, transience, a specific time of day that held meaning for them. The title itself suggests this was their time, their light.

**Transformation and Loss**: The room changing from a space of intimacy to a business office mirrors how love transforms into absence. Everything intimate has been replaced by the impersonal world of "agents, businessmen, companies."

**That Final Turn**: The shift from "a week only" to "forever" is crushing. You can feel the speaker still processing the disbelief even years later. It's about how suddenly intimacy can end, how temporary arrangements become permanent separations.

It's one of his most personal poems—stripped of historical costume, just raw memory and longing. Heartbreaking.
[Claudine]> Tax:
|                | request tokens | total tokens | request cost | total cost |
|----------------|----------------|--------------|--------------|------------|
| input          |              5 |         1116 |    $0.000015 |  $0.003348 |
| output         |            370 |         1081 |     $0.00555 |  $0.016215 |
| cache 5m write |              0 |            0 |           $0 |         $0 |
| cache 1h write |           1182 |         2636 |    $0.007092 |  $0.015816 |
| cache read     |           1454 |         2908 |   $0.0004362 | $0.0008724 |
|                |                |              |              |            |
|                |                |              |   $0.0130932 | $0.0362514 |
|
[me]> Write a similar poem
[Claudine] ...Reasoning...
[Claudine - Thinking]> The user wants me to write a poem similar to Cavafy's "The Afternoon Sun." I should capture:

1. The conversational, understated tone
2. The careful cataloging of physical objects in a space
3. The juxtaposition of past intimacy with present emptiness/transformation
4. A specific sensory detail (like the afternoon sun) that becomes symbolic
5. The devastating final turn - something seemingly temporary becoming permanent
6. Short lines, simple language, but emotionally powerful
7. The retrospective quality - looking back at a lost love

Let me write something in that spirit, but my own poem, not copying his directly.

[Claudine]> Tax:
|                | request tokens | total tokens | request cost | total cost |
|----------------|----------------|--------------|--------------|------------|
| input          |             10 |         1126 |     $0.00003 |  $0.003378 |
| output         |            471 |         1552 |    $0.007065 |   $0.02328 |
| cache 5m write |              0 |            0 |           $0 |         $0 |
| cache 1h write |           1458 |         4094 |    $0.008748 |  $0.024564 |
| cache read     |           1454 |         4362 |   $0.0004362 | $0.0013086 |
|                |                |              |              |            |
|                |                |              |   $0.0162792 | $0.0525306 |
|
[Claudine]> Using CreateFile to: Create a poem inspired by Cavafy's "The Afternoon Sun"
|
| /tmp/poetry/The_Morning_Coffee.txt
|
[Claudine] ...Processing tool results...
[Claudine]> I've written a poem inspired by Cavafy's style and themes. I tried to capture:

- **The specific geography of memory**: Like Cavafy's careful catalog of furniture, I mapped the café table, chairs, the handwritten menu
- **Transformation of space**: The intimate café becoming an impersonal phone store, mirroring his offices
- **A recurring sensory anchor**: The morning light on the coffee cup, echoing his afternoon sun
- **That devastating final turn**: "Just a few days" stretching into three years of waiting - the temporary becoming infinite
- **Understated delivery**: No grand declarations, just the simple statement "I'm still waiting" and the matter-of-fact detail about how long the phone store has been there

The poem uses the same technique of present-tense observation ("I pass it every day") collapsing into past-tense memory, then that crushing realization at the end. The modern setting (phone store instead of offices) updates it while keeping the same emotional core: places hold ghosts of intimacy.

What do you think? Does it capture something of that Cavafy quality?
[Claudine]> Tax:
|                | request tokens | total tokens | request cost | total cost |
|----------------|----------------|--------------|--------------|------------|
| input          |              6 |         1132 |    $0.000018 |  $0.003396 |
| output         |            251 |         1803 |    $0.003765 |  $0.027045 |
| cache 5m write |              0 |            0 |           $0 |         $0 |
| cache 1h write |            488 |         4582 |    $0.002928 |  $0.027492 |
| cache read     |           2912 |         7274 |   $0.0008736 | $0.0021822 |
|                |                |              |              |            |
|                |                |              |   $0.0075846 | $0.0601152 |
|
[me]> Write another one
[Claudine] ...Reasoning...
[Claudine - Thinking]> The user wants another poem in the Cavafy style. I should create a different scenario but maintain those key elements:
- Specific physical details and memory
- A space transformed
- Understated emotion
- A crushing final realization
- The gap between expectation and reality
- Perhaps a different setting this time

Let me try something different - maybe a hotel room, or a street corner, or an apartment building. I'll aim for that same quiet devastation.

[Claudine]> Tax:
|                | request tokens | total tokens | request cost | total cost |
|----------------|----------------|--------------|--------------|------------|
| input          |             10 |         1142 |     $0.00003 |  $0.003426 |
| output         |            523 |         2326 |    $0.007845 |   $0.03489 |
| cache 5m write |              0 |            0 |           $0 |         $0 |
| cache 1h write |            592 |         5174 |    $0.003552 |  $0.031044 |
| cache read     |           2912 |        10186 |   $0.0008736 | $0.0030558 |
|                |                |              |              |            |
|                |                |              |   $0.0123006 | $0.0724158 |
|
[Claudine]> Using CreateFile to: Create another poem inspired by Cavafy's style
|
| /tmp/poetry/The_Hotel_in_Prague.txt
|
[Claudine] ...Processing tool results...
[Claudine]> This one explores similar themes but with a different approach:

- **Modern technology as witness**: Using Google Street View to revisit the past adds a contemporary layer—we can literally see places we've lost, but only from the outside

- **The unreachable past**: The hotel has been renovated, upgraded, made unrecognizable—like memory itself being overwritten

- **Small, specific details**: The too-soft bed, the ironic painting, the clanking radiator, the violin player—all those tiny things that make a memory real

- **An object as talisman**: The brass room key with the wooden tag becomes a symbol he took with him, physical proof that vanished along with him

- **The ambiguous abandonment**: Unlike the directness of the other poems, this one has the unresolved quality of someone who just... disappeared. "He'd explain everything soon" but never did

- **The haunting present tense at the end**: Imagining life continuing in that space—the violin, the radiator—while the speaker remains frozen in that moment eight years ago

The poem plays with distance—geographical, temporal, emotional—and how we try to bridge it through technology, only to find ourselves more aware of what's been lost.
[Claudine]> Tax:
|                | request tokens | total tokens | request cost | total cost |
|----------------|----------------|--------------|--------------|------------|
| input          |              6 |         1148 |    $0.000018 |  $0.003444 |
| output         |            271 |         2597 |    $0.004065 |  $0.038955 |
| cache 5m write |              0 |            0 |           $0 |         $0 |
| cache 1h write |            540 |         5714 |     $0.00324 |  $0.034284 |
| cache read     |           3504 |        13690 |   $0.0010512 |  $0.004107 |
|                |                |              |              |            |
|                |                |              |   $0.0083742 |   $0.08079 |
|
[me]> 
```